### PR TITLE
fix: renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -70,7 +70,7 @@
     {
       "fileMatch": [".*\/?zarf\\.ya?ml$"],
       "matchStrings": [
-        "-\\s+['\"]?(?<depName>[^:]+):(?<currentValue>.*)['\"]?"
+        "- [\\'\"]?(?<depName>[^\"\\'\\s]+):(?<currentValue>[^\"\\'\\s]+)[\\'\"]?"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
       "datasourceTemplate": "docker",

--- a/renovate.json
+++ b/renovate.json
@@ -100,5 +100,11 @@
       ],
       "datasourceTemplate": "helm"
     }
+  ],
+    "packageRules": [
+    {
+      "matchPackageNames": ["registry1.dso.mil/ironbank/big-bang/base"],
+      "allowedVersions": "!/8.4/"
+    }
   ]
 }


### PR DESCRIPTION
## Description
Renovate is currently getting a technically real but incorrect value for `big-bang/base` (8.4) and is matching on all `- x: y` statements in zarf yamls (e.g. `- name: x` and `- cmd: kubectl ...`). This PR excludes the `8.4` version of `big-bang/base` from being used and fixes the docker regex matcher for zarf yamls to only match on `- "image:version"` or `- 'image:version'` or `- image:version`.

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-sonarqube/blob/main/CONTRIBUTING.md#developer-workflow) followed
