### PR TITLE
feat: add wait for SQ package CR readiness

### DIFF
--- a/common/zarf.yaml
+++ b/common/zarf.yaml
@@ -20,3 +20,14 @@ components:
         version: "8.0.4-bb.5"
         valuesFiles:
           - ../values/common-values.yaml
+    actions:
+      onDeploy:
+        after:
+          - description: Validate SonarQube Package
+            maxTotalSeconds: 300
+            wait:
+              cluster:
+                kind: Packages
+                name: sonarqube
+                namespace: sonarqube
+                condition: "'{.status.phase}'=Ready"


### PR DESCRIPTION
## Description

Adds a wait action for the SQ package CR. This is consistent with the pattern in uds-core however it runs after the SonarQube chart installs (meaning the SonarQube chart may still fail waiting on resources like secrets to exist) however this will catch other issues such as failed updates to resources or missing resources the chart doesn't directly depend on like netpols.

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-sonarqube/blob/main/CONTRIBUTING.md#developer-workflow) followed
