### PR TITLE
feat: allow for Postgres password secret generation

### DIFF
--- a/chart/templates/postgres-secret.yaml
+++ b/chart/templates/postgres-secret.yaml
@@ -1,0 +1,10 @@
+{{- if ne .Values.postgres.password "" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sonarqube-postgres
+  namespace: {{ .Release.Namespace }}
+type: kubernetes.io/opaque
+stringData:
+  password: {{ .Values.postgres.password }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -5,6 +5,8 @@ sso:
   saml:
     providerName: Keycloak # This is displayed on the SonarQube landing screen ("Log in with <providerName>")
 postgres:
+  password: ""
+
   internal: true
   selector:
     cluster-name: pg-cluster


### PR DESCRIPTION
## Description

This allows for the Postgres password secret to be generated in the config chart directly

## Related Issue

Fixes #86 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [X] Test, docs, adr added or updated as needed
- [X] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-sonarqube/blob/main/CONTRIBUTING.md#developer-workflow) followed
