### PR TITLE
chore: remove outdated readme note about using the registry1 chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@ The released packages can be found in [ghcr](https://github.com/defenseunicorns/
 
 Please see the [CONTRIBUTING.md](./CONTRIBUTING.md)
 
-## Notes:
-This package is currently using registry1 chart for both flavors. This is because the upstream chart depends on 'hostname' and 'wget' to be available in the images, and the registry1 images do not include these tools.
-
 ## Development
 
 When developing this package it is ideal to utilize the json schemas for UDS Bundles, Zarf Packages and Maru Tasks. This involves configuring your IDE to provide schema validation for the respective files used by each application. For guidance on how to set up this schema validation, please refer to the [guide](https://github.com/defenseunicorns/uds-common/blob/main/docs/development-ide-configuration.md) in uds-common.


### PR DESCRIPTION
## Description

README.md still had an old note about the registry1 chart. We moved to the upstream chart so removing this note.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-sonarqube/blob/main/CONTRIBUTING.md#developer-workflow) followed
