### PR TITLE
chore: update releaser.yaml renovate versioning type to docker

### DIFF
--- a/releaser.yaml
+++ b/releaser.yaml
@@ -3,11 +3,11 @@
 
 flavors:
   - name: upstream
-    # renovate-uds: datasource=docker depName=sonarqube extractVersion=^(?<version>\d+\.\d+\.\d+\.\d+)(-community)?$
+    # renovate-uds: datasource=docker versioning=docker depName=sonarqube extractVersion=^(?<version>\d+\.\d+\.\d+\.\d+)(-community)?$
     version: 24.12.0.100206-uds.0
   - name: registry1
     # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/sonarsource/sonarqube/sonarqube-community-build extractVersion=^(?<version>\d+\.\d+\.\d+\.\d+)(-community)?$
     version: 24.12.0.100206-uds.0
   - name: unicorn
-    # renovate-uds: datasource=docker depName=cgr.dev/du-uds-defenseunicorns/sonarqube
+    # renovate-uds: datasource=docker versioning=docker depName=cgr.dev/du-uds-defenseunicorns/sonarqube
     version: 24.12.0.100206-uds.0

--- a/releaser.yaml
+++ b/releaser.yaml
@@ -6,7 +6,7 @@ flavors:
     # renovate-uds: datasource=docker versioning=docker depName=sonarqube extractVersion=^(?<version>\d+\.\d+\.\d+\.\d+)(-community)?$
     version: 24.12.0.100206-uds.0
   - name: registry1
-    # renovate-uds: datasource=docker depName=registry1.dso.mil/ironbank/sonarsource/sonarqube/sonarqube-community-build extractVersion=^(?<version>\d+\.\d+\.\d+\.\d+)(-community)?$
+    # renovate-uds: datasource=docker versioning=docker depName=registry1.dso.mil/ironbank/sonarsource/sonarqube/sonarqube-community-build extractVersion=^(?<version>\d+\.\d+\.\d+\.\d+)(-community)?$
     version: 24.12.0.100206-uds.0
   - name: unicorn
     # renovate-uds: datasource=docker versioning=docker depName=cgr.dev/du-uds-defenseunicorns/sonarqube


### PR DESCRIPTION
## Description

Updates the versioning scheme for renovate to 'docker' instead of the default of 'semver-coerced' that is defined in uds-common. This is to allow the 4 segment docker version number to work.

Tested in a personal repo against upstream here: https://github.com/ericwyles/renovate-test/pull/2/files

Docs for renovate 'docker' versioning: https://docs.renovatebot.com/modules/versioning/docker/
