### PR TITLE
chore: fix matrix exclusions for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
         flavor: [upstream, registry1, unicorn]
         architecture: [amd64, arm64]
         exclude:
-          - flavor: registry1
+          - flavor: [registry1, unicorn]
             architecture: arm64
     uses: defenseunicorns/uds-common/.github/workflows/callable-publish.yaml@2c146b9da5a437da70b2506796b899cd8fa2c03c # v1.15.0
     with:


### PR DESCRIPTION
## Description

There is no longer a unicorn arm image so we need to remove it from the release matrix. 
