### PR TITLE
fix: remove playwright image from package deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,7 @@
         "package-deps"
       ],
       "commitMessageTopic": "package-deps",
+      "matchPackageNames": ["!/^mcr\\.microsoft\\.com\\/playwright$/"],
       "matchDatasources": [
         "docker",
         "helm",


### PR DESCRIPTION
## Description

Removes the playwright image from package deps which will add it to the support deps alongside its package version

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-sonarqube/blob/main/CONTRIBUTING.md#developer-workflow) followed
